### PR TITLE
fix(detection): avoid loading backbone weight when imported from hub

### DIFF
--- a/official/vision/detection/configs/faster_rcnn_res101_coco_2x_800size.py
+++ b/official/vision/detection/configs/faster_rcnn_res101_coco_2x_800size.py
@@ -33,7 +33,9 @@ def faster_rcnn_res101_coco_2x_800size(batch_size=1, **kwargs):
     `"FPN" <https://arxiv.org/abs/1612.03144>`_
     `"COCO" <https://arxiv.org/abs/1405.0312>`_
     """
-    return models.FasterRCNN(CustomFasterRCNNConfig(), batch_size=batch_size, **kwargs)
+    cfg = CustomFasterRCNNConfig()
+    cfg.backbone_pretrained = False
+    return models.FasterRCNN(cfg, batch_size=batch_size, **kwargs)
 
 
 Net = models.FasterRCNN

--- a/official/vision/detection/configs/faster_rcnn_res50_coco_1x_800size.py
+++ b/official/vision/detection/configs/faster_rcnn_res50_coco_1x_800size.py
@@ -22,7 +22,9 @@ def faster_rcnn_res50_coco_1x_800size(batch_size=1, **kwargs):
     `"FPN" <https://arxiv.org/abs/1612.03144>`_
     `"COCO" <https://arxiv.org/abs/1405.0312>`_
     """
-    return models.FasterRCNN(models.FasterRCNNConfig(), batch_size=batch_size, **kwargs)
+    cfg = models.FasterRCNNConfig()
+    cfg.backbone_pretrained = False
+    return models.FasterRCNN(cfg, batch_size=batch_size, **kwargs)
 
 
 Net = models.FasterRCNN

--- a/official/vision/detection/configs/faster_rcnn_res50_coco_1x_800size_syncbn.py
+++ b/official/vision/detection/configs/faster_rcnn_res50_coco_1x_800size_syncbn.py
@@ -32,7 +32,9 @@ def faster_rcnn_res50_coco_1x_800size_syncbn(batch_size=1, **kwargs):
     `"COCO" <https://arxiv.org/abs/1405.0312>`_
     `"SyncBN" <https://arxiv.org/abs/1711.07240>`_
     """
-    return models.FasterRCNN(CustomFasterRCNNConfig(), batch_size=batch_size, **kwargs)
+    cfg = CustomFasterRCNNConfig()
+    cfg.backbone_pretrained = False
+    return models.FasterRCNN(cfg, batch_size=batch_size, **kwargs)
 
 
 Net = models.FasterRCNN

--- a/official/vision/detection/configs/faster_rcnn_resx101_coco_2x_800size.py
+++ b/official/vision/detection/configs/faster_rcnn_resx101_coco_2x_800size.py
@@ -33,7 +33,9 @@ def faster_rcnn_resx101_coco_2x_800size(batch_size=1, **kwargs):
     `"FPN" <https://arxiv.org/abs/1612.03144>`_
     `"COCO" <https://arxiv.org/abs/1405.0312>`_
     """
-    return models.FasterRCNN(CustomFasterRCNNConfig(), batch_size=batch_size, **kwargs)
+    cfg = CustomFasterRCNNConfig()
+    cfg.backbone_pretrained = False
+    return models.FasterRCNN(cfg, batch_size=batch_size, **kwargs)
 
 
 Net = models.FasterRCNN

--- a/official/vision/detection/configs/retinanet_res101_coco_2x_800size.py
+++ b/official/vision/detection/configs/retinanet_res101_coco_2x_800size.py
@@ -33,7 +33,9 @@ def retinanet_res101_coco_2x_800size(batch_size=1, **kwargs):
     `"FPN" <https://arxiv.org/abs/1612.03144>`_
     `"COCO" <https://arxiv.org/abs/1405.0312>`_
     """
-    return models.RetinaNet(CustomRetinaNetConfig(), batch_size=batch_size, **kwargs)
+    cfg = CustomRetinaNetConfig()
+    cfg.backbone_pretrained = False
+    return models.RetinaNet(cfg, batch_size=batch_size, **kwargs)
 
 
 Net = models.RetinaNet

--- a/official/vision/detection/configs/retinanet_res50_coco_1x_800size.py
+++ b/official/vision/detection/configs/retinanet_res50_coco_1x_800size.py
@@ -22,7 +22,9 @@ def retinanet_res50_coco_1x_800size(batch_size=1, **kwargs):
     `"FPN" <https://arxiv.org/abs/1612.03144>`_
     `"COCO" <https://arxiv.org/abs/1405.0312>`_
     """
-    return models.RetinaNet(models.RetinaNetConfig(), batch_size=batch_size, **kwargs)
+    cfg = models.RetinaNetConfig()
+    cfg.backbone_pretrained = False
+    return models.RetinaNet(cfg, batch_size=batch_size, **kwargs)
 
 
 Net = models.RetinaNet

--- a/official/vision/detection/configs/retinanet_res50_coco_1x_800size_syncbn.py
+++ b/official/vision/detection/configs/retinanet_res50_coco_1x_800size_syncbn.py
@@ -32,7 +32,9 @@ def retinanet_res50_coco_1x_800size_syncbn(batch_size=1, **kwargs):
     `"COCO" <https://arxiv.org/abs/1405.0312>`_
     `"SyncBN" <https://arxiv.org/abs/1711.07240>`_
     """
-    return models.RetinaNet(CustomRetinaNetConfig(), batch_size=batch_size, **kwargs)
+    cfg = CustomRetinaNetConfig()
+    cfg.backbone_pretrained = False
+    return models.RetinaNet(cfg, batch_size=batch_size, **kwargs)
 
 
 Net = models.RetinaNet

--- a/official/vision/detection/configs/retinanet_resx101_coco_2x_800size.py
+++ b/official/vision/detection/configs/retinanet_resx101_coco_2x_800size.py
@@ -33,7 +33,9 @@ def retinanet_resx101_coco_2x_800size(batch_size=1, **kwargs):
     `"FPN" <https://arxiv.org/abs/1612.03144>`_
     `"COCO" <https://arxiv.org/abs/1405.0312>`_
     """
-    return models.RetinaNet(CustomRetinaNetConfig(), batch_size=batch_size, **kwargs)
+    cfg = CustomRetinaNetConfig()
+    cfg.backbone_pretrained = False
+    return models.RetinaNet(cfg, batch_size=batch_size, **kwargs)
 
 
 Net = models.RetinaNet


### PR DESCRIPTION
目前在用hub load detection模型时，会额外load一次backbone weights，这一次load是不必要的
修改方式为在hub接口中修改`cfg.backbone_pretrained = False`
`train.py` `test.py` `inference.py`通过`-f`读取`Cfg`，所以不会被影响。