### PR TITLE
fix(detection): pad before norm in preparing

### DIFF
--- a/official/vision/detection/models/faster_rcnn.py
+++ b/official/vision/detection/models/faster_rcnn.py
@@ -67,10 +67,12 @@ class FasterRCNN(M.Module):
         }
 
     def preprocess_image(self, image):
+        padded_image = layers.get_padded_tensor(image, 32, 0.0)
         normed_image = (
-            image - np.array(self.cfg.img_mean, dtype=np.float32)[None, :, None, None]
+            padded_image
+            - np.array(self.cfg.img_mean, dtype=np.float32)[None, :, None, None]
         ) / np.array(self.cfg.img_std, dtype=np.float32)[None, :, None, None]
-        return layers.get_padded_tensor(normed_image, 32, 0.0)
+        return normed_image
 
     def forward(self, inputs):
         images = inputs["image"]

--- a/official/vision/detection/models/retinanet.py
+++ b/official/vision/detection/models/retinanet.py
@@ -81,10 +81,12 @@ class RetinaNet(M.Module):
         self.loss_normalizer = mge.tensor(100.0)
 
     def preprocess_image(self, image):
+        padded_image = layers.get_padded_tensor(image, 32, 0.0)
         normed_image = (
-            image - np.array(self.cfg.img_mean, dtype=np.float32)[None, :, None, None]
+            padded_image
+            - np.array(self.cfg.img_mean, dtype=np.float32)[None, :, None, None]
         ) / np.array(self.cfg.img_std, dtype=np.float32)[None, :, None, None]
-        return layers.get_padded_tensor(normed_image, 32, 0.0)
+        return normed_image
 
     def forward(self, inputs):
         image = self.preprocess_image(inputs["image"])
@@ -98,7 +100,8 @@ class RetinaNet(M.Module):
             for _ in box_logits
         ]
         box_offsets_list = [
-            _.dimshuffle(0, 2, 3, 1).reshape(self.batch_size, -1, 4) for _ in box_offsets
+            _.dimshuffle(0, 2, 3, 1).reshape(self.batch_size, -1, 4)
+            for _ in box_offsets
         ]
 
         anchors_list = [

--- a/official/vision/detection/tools/inference.py
+++ b/official/vision/detection/tools/inference.py
@@ -57,8 +57,8 @@ def main():
     data, im_info = DetEvaluator.process_inputs(
         ori_img.copy(), model.cfg.test_image_short_size, model.cfg.test_image_max_size,
     )
+    model.inputs["image"].set_value(data)
     model.inputs["im_info"].set_value(im_info)
-    model.inputs["image"].set_value(data.astype(np.float32))
     pred_res = evaluator.predict(val_func)
     res_img = DetEvaluator.vis_det(
         ori_img, pred_res, is_show_label=True, classes=COCO.class_names,

--- a/official/vision/detection/tools/test.py
+++ b/official/vision/detection/tools/test.py
@@ -175,8 +175,8 @@ def worker(
             model.cfg.test_image_short_size,
             model.cfg.test_image_max_size,
         )
+        model.inputs["image"].set_value(data)
         model.inputs["im_info"].set_value(im_info)
-        model.inputs["image"].set_value(data.astype(np.float32))
 
         pred_res = evaluator.predict(val_func)
         result_queue.put_nowait(

--- a/official/vision/detection/tools/utils.py
+++ b/official/vision/detection/tools/utils.py
@@ -89,7 +89,7 @@ class DetectionPadCollator(Collator):
         batch_data = defaultdict(list)
 
         for image, boxes, boxes_category, info in inputs:
-            batch_data["data"].append(image)
+            batch_data["data"].append(image.astype(np.float32))
             batch_data["gt_boxes"].append(
                 np.concatenate([boxes, boxes_category[:, np.newaxis]], axis=1).astype(
                     np.float32
@@ -172,7 +172,7 @@ class DetEvaluator:
         )
         resized_img = cv2.flip(resized_img, 1) if flip else resized_img
         trans_img = np.ascontiguousarray(
-            resized_img.transpose(2, 0, 1)[None, :, :, :], dtype=np.uint8
+            resized_img.transpose(2, 0, 1)[None, :, :, :], dtype=np.float32
         )
         im_info = np.array(
             [(resized_height, resized_width, original_height, original_width)],


### PR DESCRIPTION
dataloader出来的是[0, 255] padding 0的image。
按照原来的逻辑，会先norm再padding 0，会出现padding不一致的情况，先padding 0后norm可以避免。
已经验证过现有hub weights不需要更新。

怀疑是Objects365会nan的原因之一，暂无验证。