### PR TITLE
fix(quantization): fix the order of quantize and load checkpoint

### DIFF
--- a/official/quantization/inference.py
+++ b/official/quantization/inference.py
@@ -52,14 +52,14 @@ def main():
     if args.mode != "normal":
         quantize_qat(model, qconfig=Q.ema_fakequant_qconfig)
 
-    if args.mode == "quantized":
-        quantize(model)
-
     if args.checkpoint:
         logger.info("Load pretrained weights from %s", args.checkpoint)
         ckpt = mge.load(args.checkpoint)
         ckpt = ckpt["state_dict"] if "state_dict" in ckpt else ckpt
         model.load_state_dict(ckpt, strict=False)
+
+    if args.mode == "quantized":
+        quantize(model)
 
     rpath = os.path.realpath(__file__ + "/../../")
     if args.image is None:


### PR DESCRIPTION
- 目前不支持直接加载quantized model，因为quantized Module的output scale并没有作为state存下来
  - 就算支持，mode=quantized也难以使用，因为目前开启后是load一个quantized模型，而不是生成一个quantized模型并保存，意味着没有从0到1的过程（除了直接读官方提供的模型）
- 其实更合适的做法是把mode=quantized作为另一个维度的选项，比如args.convert=True/False，即是否转换成quantized Module，这里为了和以前的教程视频兼容，暂不做修改