### PR TITLE
fix(dump): modify the default value format of shape argument in class…

### DIFF
--- a/official/vision/classification/dump.py
+++ b/official/vision/classification/dump.py
@@ -53,7 +53,7 @@ def main():
         "--shape",
         type=int,
         nargs=4,
-        default="1 3 224 224",
+        default=(1, 3, 224, 224),
         help="input shape (default: 1 3 224 224)"
     )
     parser.add_argument(


### PR DESCRIPTION
dump分类模型的脚本的shape参数的默认值无法运行，原始默认值`1 3 224 224`，现修改为`(1, 3, 224, 224)`
```
>> python dump.py
err: Failed to load cuda API library
err: failed to load cuda func: cuCtxGetCurrent
usage: dump.py [-h] [-a ARCH] [-s SHAPE SHAPE SHAPE SHAPE] [-o OUTPUT]
dump.py: error: argument -s/--shape: invalid int value: '1 3 224 224'